### PR TITLE
feat(phase-x): integrate Gemma 3-4B-it with --ngl & docs

### DIFF
--- a/models/model_paths.json
+++ b/models/model_paths.json
@@ -1,0 +1,4 @@
+{
+  "llama2-7b":  "D:/models/Llama-2-7B-Chat-GGUF/llama-2-7b-chat.Q4_K_M.gguf",
+  "gemma3n-4b": "D:/models/gemma3n-4bit/gemma-3-4b-it.Q4_K_M.gguf"
+}

--- a/phase-x/modules/×_VERIFY.MULTI/README.md
+++ b/phase-x/modules/×_VERIFY.MULTI/README.md
@@ -1,35 +1,25 @@
-# × VERIFY.MULTI – EchoOS Phase X
+# × VERIFY.MULTI – Offline Multi-Model Verifier
 
-> **Run one prompt set through multiple local LLM models and check consistency**
+Runs the same **trace JSONL** through any number of `llama-cli` GGUF models,  
+optionally measures response similarity, and writes the results back to
+`*.jsonl`.
 
 ---
 
-## Features
+## ✨ 2025-07 update
 
-* CLI wrapper around **`llama-cli`** for batch inference
-* Supports **any number of `.gguf` models** in one run
-* Logs per-model JSON, plus a `results.jsonl` summary
-* Built-in similarity metrics  
-  * **Jaccard token overlap** (always on)  
-  * **FH-score** (embedding cosine – optional, needs `sentence-transformers`)
-* Windows / Linux tested, Python ≥ 3.10
+| Change | Details |
+| ------ | ------- |
+| **Central model map** | `models/model_paths.json` stores *model-key → file path* |
+| **New flag** `--ngl` | Maps to `llama-cli --gpu-layers` (CUDA/Metal off-load) |
+| **No chat hang-ups** | `-no-cnv` is injected automatically to skip interactive mode |
+| **Gemma 3-4B-it support** | Tested with `Q4_K_M` (≈ 2.3 GiB, 5-7 tok/s on RTX 4060) |
 
-## Quick start
+---
+
+## Installation
 
 ```bash
-# ① install deps
-python -m pip install -r requirements.txt
-
-# ② run
-python verify_multi.py \
-  --input   ../../traces/dev/trace_smoke.jsonl \
-  --models  D:/models/llama/llama-2-7b.Q4_K_M.gguf \
-            D:/models/llama/gemma-2b.Q4_K_M.gguf \
-  --llama-cli "D:/models/llama-bin/llama-cli.exe" \
-  --n-tokens 128 --temp 0.7 \
-  --output  ../../results/dev_run
-
-If your llama-cli < b5500, use --skip-json or upgrade to get structured output.
-
-#3 update
-Old version llama-cli→stderr Merge、build-in filtering noise
+pip install -r requirements.txt          # tqdm + sentencepiece
+# For similarity scoring (optional)
+pip install sentence-transformers

--- a/phase-x/modules/×_VERIFY.MULTI/requirements.txt
+++ b/phase-x/modules/×_VERIFY.MULTI/requirements.txt
@@ -1,6 +1,6 @@
-﻿# --- core runtime ---
-tqdm>=4.65              # progress bar
+﻿# Core runtime dependencies
+tqdm>=4.67
+sentencepiece>=0.2.0
 
-# --- optional (FH-score / embedding cosine) ---
-# Install command：pip install -r requirements.txt[fh] 
-sentence-transformers>=0.7 ; extra == "fh"
+# Optional: enable --compare-similarity (cosine distance via SBERT)
+# sentence-transformers>=0.6.0


### PR DESCRIPTION
What’s new

Added models/model_paths.json for central GGUF mapping

verify_multi.py now accepts model keys, supports --ngl, forces -no-cnv

English README + requirements update (Gemma example)

Smoke test passes with Gemma 3-4B-it and Llama-2-7B

Test plan

trace_smoke.jsonl → verify_multi_out/ responses non-empty

RTX 4060: Gemma tok/s ≈ 5–7, Llama2 tok/s ≈ 4–6